### PR TITLE
MMR verification interfaces

### DIFF
--- a/contracts/MMRVerification.sol
+++ b/contracts/MMRVerification.sol
@@ -69,6 +69,7 @@ abstract contract MMRVerification {
     function executeMessages(
         bytes32 blockHeader,
         bytes32 paraHeadHash,
-        bytes32[] memory messages
+        bytes32[] memory messages,
+        bytes32 mmrSiblingsProof
     ) virtual public;
 }

--- a/contracts/MMRVerification.sol
+++ b/contracts/MMRVerification.sol
@@ -1,0 +1,74 @@
+// "SPDX-License-Identifier: UNLICENSED"
+pragma solidity ^0.7.0;
+
+/**
+    The assumed MMR data structure on Substrate is from https://github.com/paritytech/substrate/pull/7312/files,
+    with some slight modifications for gas optimization (hashing Vec<ParaHead>, adding Option<H256> pub key root):
+
+    MMRLeaf {
+        H256 (Polkadot block header hash)
+        H256 (hash of Vec<ParaHead>)
+        Vec<BridgeMessage>
+        Option<H256> (merkle root of a tree of new validator pubkey)
+    }
+ */
+
+abstract contract MMRVerification {
+
+    // Contract storage:
+    // - current byte32 MMR root (future: array of current + previous roots as a circular queue with size N)
+    // - current public keys of validator set (optimization: merkle tree of public keys, only store root)
+
+    /**
+     * @dev Updates the current MMR root, validating the new proposed MMR root by a
+     *      subset of validator signatures. Called every time a new MMR root is available.
+     * @param newMmrRoot the new proposed MMR root.
+     * @param signatures the subset of validator signatures on this MMR root.
+     * @param bitmap a bitmap indicating which validators the signatures belong to.
+     */
+    function updateMMR(
+        bytes32 newMmrRoot,
+        bytes32[] memory signatures,
+        uint8[] memory bitmap
+    ) virtual public returns (bool);
+
+    /**
+     * @dev Updates the current MMR root and updates the validator set. Called instead of
+     *      `updateMMR` for blocks which include a validator set change commitment.
+     * @param newMmrRoot
+     * @param signatures
+     * @param bitmap
+     * @param valPubKeys
+     * @param pubKeyProof
+     */
+    function updateMMRWithValSet(
+        bytes32 newMmrRoot,
+        bytes32[] memory signatures,
+        uint8[] memory bitmap,
+        bytes32[] memory valPubKeys,
+        bytes32 pubKeyProof
+    ) virtual public returns(bool);
+
+    /**
+     * @dev Updates the set of validator public keys stored on contract.
+     * @param valPubKeys array of new validator public keys
+     * @param pubKeyProof merkle proof of the new validator public keys in the MMR
+     */
+    function updateValSet(
+        bytes32[] memory valPubKeys,
+        bytes32 pubKeyProof
+    ) virtual internal returns (bool);
+
+    /**
+     * @dev Validate that a set of messages is contained and executes them.
+     * @param blockHeader the header hash of the block containing the messages.
+     * @param paraHeadHash hash resulting from the parachain headers.
+     * @param messages flat list of all messages.
+     * @param mmrSiblingsProof hash of the mmr's siblings.
+     */
+    function executeMessages(
+        bytes32 blockHeader,
+        bytes32 paraHeadHash,
+        bytes32[] memory messages
+    ) virtual public;
+}

--- a/contracts/MMRVerification.sol
+++ b/contracts/MMRVerification.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.7.0;
 
 /**
     The assumed MMR data structure on Substrate is from https://github.com/paritytech/substrate/pull/7312/files,
-    with some slight modifications for gas optimization (hashing Vec<ParaHead>, adding Option<H256> pub key root):
+    with some slight modifications for gas optimization (merkle root of ParaHeads, adding Option<H256> pub key root):
 
     MMRLeaf {
         H256 (Polkadot block header hash)
-        H256 (hash of Vec<ParaHead>)
-        Vec<BridgeMessage>
+        H256 (root of merkle tree of `ParaHead`s)
+        H256 (root of merkle tree of BridgeMessage)
         Option<H256> (merkle root of a tree of new validator pubkey)
     }
  */
@@ -17,14 +17,15 @@ abstract contract MMRVerification {
 
     // Contract storage:
     // - current byte32 MMR root (future: array of current + previous roots as a circular queue with size N)
-    // - current public keys of validator set (optimization: merkle tree of public keys, only store root)
+    // - current public keys of validator set (optimization: merkle tree of public keys, only store root,
+    //   future: array of current + previous roots as a circular queue with size N).
 
     /**
      * @dev Updates the current MMR root, validating the new proposed MMR root by a
      *      subset of validator signatures. Called every time a new MMR root is available.
      * @param newMmrRoot the new proposed MMR root.
-     * @param signatures the subset of validator signatures on this MMR root.
-     * @param bitmap a bitmap indicating which validators the signatures belong to.
+     * @param signatures[] the subset of validator signatures on this MMR root.
+     * @param bitmap[] a bitmap indicating which validators the signatures belong to.
      */
     function updateMMR(
         bytes32 newMmrRoot,
@@ -36,40 +37,42 @@ abstract contract MMRVerification {
      * @dev Updates the current MMR root and updates the validator set. Called instead of
      *      `updateMMR` for blocks which include a validator set change commitment.
      * @param newMmrRoot the new proposed MMR root.
-     * @param signatures the subset of validator signatures on this MMR root.
-     * @param bitmap a bitmap indicating which validators the signatures belong to.
-     * @param valPubKeys array of new validator public keys.
-     * @param pubKeyProof merkle proof of the new validator public keys in the MMR.
+     * @param signatures[] the subset of validator signatures on this MMR root.
+     * @param bitmap[] bitmap indicating which validators the signatures belong to.
+     * @param valPubKeys[] new validator public keys.
+     * @param pubKeyProof[] merkle proof of the new validator public keys in the MMR.
      */
     function updateMMRWithValSet(
         bytes32 newMmrRoot,
         bytes32[] memory signatures,
         uint8[] memory bitmap,
         bytes32[] memory valPubKeys,
-        bytes32 pubKeyProof
+        bytes32[] memory pubKeyProof
     ) virtual public returns(bool);
 
     /**
      * @dev Updates the set of validator public keys stored on contract.
-     * @param valPubKeys array of new validator public keys.
-     * @param pubKeyProof merkle proof of the new validator public keys in the MMR.
+     * @param valPubKeys[] new validator public keys.
+     * @param pubKeyProof[] merkle proof of the new validator public keys in the MMR.
      */
     function updateValSet(
         bytes32[] memory valPubKeys,
-        bytes32 pubKeyProof
+        bytes32[] memory pubKeyProof
     ) virtual internal returns (bool);
 
     /**
      * @dev Validate that a set of messages is contained and executes them.
      * @param blockHeader the header hash of the block containing the messages.
-     * @param paraHeadHash hash resulting from the parachain headers.
-     * @param messages flat list of all messages.
-     * @param mmrSiblingsProof hash of the mmr's siblings.
+     * @param paraHead parachain Header.
+     * @param paraHeadSiblingsProof[] hashes of siblings needed for the merkle proof of the parachain header.
+     * @param messages[] flat list of all messages.
+     * @param mmrSiblingsProof[] hashes of the mmr's siblings.
      */
     function executeMessages(
         bytes32 blockHeader,
-        bytes32 paraHeadHash,
+        bytes32 paraHead,
+        bytes32[] memory paraHeadSiblingsProof,
         bytes32[] memory messages,
-        bytes32 mmrSiblingsProof
+        bytes32[] memory mmrSiblingsProof
     ) virtual public;
 }

--- a/contracts/MMRVerification.sol
+++ b/contracts/MMRVerification.sol
@@ -24,8 +24,8 @@ abstract contract MMRVerification {
      * @dev Updates the current MMR root, validating the new proposed MMR root by a
      *      subset of validator signatures. Called every time a new MMR root is available.
      * @param newMmrRoot the new proposed MMR root.
-     * @param signatures[] the subset of validator signatures on this MMR root.
-     * @param bitmap[] a bitmap indicating which validators the signatures belong to.
+     * @param signatures the subset of validator signatures on this MMR root.
+     * @param bitmap a bitmap indicating which validators the signatures belong to.
      */
     function updateMMR(
         bytes32 newMmrRoot,
@@ -37,10 +37,10 @@ abstract contract MMRVerification {
      * @dev Updates the current MMR root and updates the validator set. Called instead of
      *      `updateMMR` for blocks which include a validator set change commitment.
      * @param newMmrRoot the new proposed MMR root.
-     * @param signatures[] the subset of validator signatures on this MMR root.
-     * @param bitmap[] bitmap indicating which validators the signatures belong to.
-     * @param valPubKeys[] new validator public keys.
-     * @param pubKeyProof[] merkle proof of the new validator public keys in the MMR.
+     * @param signatures the subset of validator signatures on this MMR root.
+     * @param bitmap bitmap indicating which validators the signatures belong to.
+     * @param valPubKeys new validator public keys.
+     * @param pubKeyProof merkle proof of the new validator public keys in the MMR.
      */
     function updateMMRWithValSet(
         bytes32 newMmrRoot,
@@ -52,8 +52,8 @@ abstract contract MMRVerification {
 
     /**
      * @dev Updates the set of validator public keys stored on contract.
-     * @param valPubKeys[] new validator public keys.
-     * @param pubKeyProof[] merkle proof of the new validator public keys in the MMR.
+     * @param valPubKeys new validator public keys.
+     * @param pubKeyProof merkle proof of the new validator public keys in the MMR.
      */
     function updateValSet(
         bytes32[] memory valPubKeys,
@@ -64,9 +64,9 @@ abstract contract MMRVerification {
      * @dev Validate that a set of messages is contained and executes them.
      * @param blockHeader the header hash of the block containing the messages.
      * @param paraHead parachain Header.
-     * @param paraHeadSiblingsProof[] hashes of siblings needed for the merkle proof of the parachain header.
-     * @param messages[] flat list of all messages.
-     * @param mmrSiblingsProof[] hashes of the mmr's siblings.
+     * @param paraHeadSiblingsProof hashes of siblings needed for the merkle proof of the parachain header.
+     * @param messages flat list of all messages.
+     * @param mmrSiblingsProof hashes of the mmr's siblings.
      */
     function executeMessages(
         bytes32 blockHeader,

--- a/contracts/MMRVerification.sol
+++ b/contracts/MMRVerification.sol
@@ -35,11 +35,11 @@ abstract contract MMRVerification {
     /**
      * @dev Updates the current MMR root and updates the validator set. Called instead of
      *      `updateMMR` for blocks which include a validator set change commitment.
-     * @param newMmrRoot
-     * @param signatures
-     * @param bitmap
-     * @param valPubKeys
-     * @param pubKeyProof
+     * @param newMmrRoot the new proposed MMR root.
+     * @param signatures the subset of validator signatures on this MMR root.
+     * @param bitmap a bitmap indicating which validators the signatures belong to.
+     * @param valPubKeys array of new validator public keys.
+     * @param pubKeyProof merkle proof of the new validator public keys in the MMR.
      */
     function updateMMRWithValSet(
         bytes32 newMmrRoot,
@@ -51,8 +51,8 @@ abstract contract MMRVerification {
 
     /**
      * @dev Updates the set of validator public keys stored on contract.
-     * @param valPubKeys array of new validator public keys
-     * @param pubKeyProof merkle proof of the new validator public keys in the MMR
+     * @param valPubKeys array of new validator public keys.
+     * @param pubKeyProof merkle proof of the new validator public keys in the MMR.
      */
     function updateValSet(
         bytes32[] memory valPubKeys,


### PR DESCRIPTION
This PR defines the interfaces required for MMR verification.
1. Updating/appending a new MMR root.
2. Updating the validator set.
3. Executing a set of messages.

It assumes that the MMR data structure stored off-chain is similar to the MMR data structure defined in https://github.com/paritytech/substrate/pull/7312/files with some slight modifications for gas optimization (hashing `Vec<ParaHead>`, adding `Option<H256> pub key root`):

```
  MMRLeaf {
        H256 (Polkadot block header hash)
        H256 (hash of Vec<ParaHead>)
        Vec<BridgeMessage>
        Option<H256> (merkle root of a tree of new validator pubkey)
    }
```